### PR TITLE
BUG: fix DuplCapture flicker mentioned in (#552)

### DIFF
--- a/src/Captura.Windows/DesktopDuplication/DuplCapture.cs
+++ b/src/Captura.Windows/DesktopDuplication/DuplCapture.cs
@@ -106,7 +106,7 @@ namespace Captura.Windows.DesktopDuplication
                         0,
                         TargetPosition.X, TargetPosition.Y);
 
-                    return true;
+                    return false;
                 }
 
                 if (acquireResult.Result.Failure)


### PR DESCRIPTION
Flicker is due to DesktopDuplicatin timeout owing to no fresh frame rendered by Window. Return false, then the RepeatFrame.Instance will be passed to the Video and Preview writer.

